### PR TITLE
Dispose reaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ setTimeout(() => {
   - methods
     - **rehydrate** *function*
       - returns *IHydrateResult*
+    - **dispose** *function*
+      - disposes reaction which is useful if you want to call `create` again with different config
 
 ## Examples
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -9,5 +9,6 @@ export interface optionsType {
 }
 export interface IHydrateResult<T> extends Promise<T> {
     rehydrate: () => IHydrateResult<T>;
+    dispose: () => void;
 }
-export declare function create({storage, jsonify, debounce}?: any): <T extends Object>(key: string, store: T, initialState?: any, customArgs?: any) => IHydrateResult<T>;
+export declare function create({ storage, jsonify, debounce }?: any): <T extends Object>(key: string, store: T, initialState?: any, customArgs?: any) => IHydrateResult<T>;

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ function create(_a) {
             return promise;
         }
         var result = hydration();
-        mobx_1.reaction(function () { return serializr_1.serialize(schema, store); }, function (data) { return storage.setItem(key, !jsonify ? data : JSON.stringify(data)); }, {
+        result.dispose = mobx_1.reaction(function () { return serializr_1.serialize(schema, store); }, function (data) { return storage.setItem(key, !jsonify ? data : JSON.stringify(data)); }, {
             delay: debounce
         });
         return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,8 @@ export interface optionsType {
 }
 
 export interface IHydrateResult<T> extends Promise<T> {
-    rehydrate: () => IHydrateResult<T>
+    rehydrate: () => IHydrateResult<T>,
+    dispose: () => void
 }
 
 export function create({
@@ -58,7 +59,7 @@ export function create({
             return promise
         }
         const result = hydration()
-        reaction(
+        result.dispose = reaction(
             () => serialize(schema, store),
             (data: any) => storage.setItem(key, !jsonify ? data : JSON.stringify(data)),
             {


### PR DESCRIPTION
This is useful if user would like to call `create` again with different config.
For example:
1. Call `create` with localStorage set and add some hydrations
2. Persist some data (change some observable value) in store ABC
3. Call `create` again with localStorage = undefined
4. Persist some data again (change some observable value).
If previous reaction from store ABC is not disposed then data will be saved to localStorage anyway.
That's why `dispose` can be useful in such cases.