### PR TITLE
Make hydratation disposable

### DIFF
--- a/dev/app-state.ts
+++ b/dev/app-state.ts
@@ -23,7 +23,7 @@ class AppState extends BaseState
   @persist('list') @observable list: number[] = [2, 22]
   @persist('list', Item) @observable classList: Item[] = []
   @persist('list') @observable objectList: any[] = [{ test: 1 }, null, undefined, [1]]
-  @persist('map', Item) @observable map = observable.map<Item>({})
+  @persist('map', Item) @observable map = observable.map<Item, any>({})
   @persist('object', Item) @observable item = new Item
   @persist('object') @observable date: Date
 

--- a/dev/app.tsx
+++ b/dev/app.tsx
@@ -8,7 +8,7 @@ class App extends React.Component<any, any> {
     return (
       <div>
         <div>{this.props.appState.count}</div>
-        <button onClick={this.onReset}>
+        <button onClick={this.props.onDispose || this.onReset}>
           Seconds passed: {this.props.appState.count}
         </button>
         <button onClick={this.onAdd}>Class List Count: {

--- a/dev/index.tsx
+++ b/dev/index.tsx
@@ -8,9 +8,14 @@ import { create } from '../src'
 
 const hydrate = create({})
 
-const appState = new AppState
+const appState = new AppState();
+const disposeState = new AppState();
+
 hydrate('appState', appState, (window as any).__INITIAL_STATE__.app)
   .then(() => console.log('appState hydrated'))
+
+const disposable = hydrate('disposeState', disposeState);
+
 hydrate('noDecoratorState', noDecoratorState)
   .then(() => console.log('noDecoratorState hydrated'))
 
@@ -18,6 +23,8 @@ render(
   <AppContainer>
     <div>
       <App appState={appState} />
+      <hr />
+      <App appState={disposeState} onDispose={disposable.dispose} />
       <hr />
       <NoDecorator />
     </div>
@@ -35,6 +42,8 @@ if (m.hot) {
       <AppContainer>
         <div>
           <App appState={appState} />
+          <hr />
+          <App appState={disposeState} onDispose={disposable.dispose} />
           <hr />
           <NoDecorator />
         </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export interface optionsType {
 
 export interface IHydrateResult<T> extends Promise<T> {
     rehydrate: () => IHydrateResult<T>
+    dispose: () => void;
 }
 
 export function create({
@@ -58,13 +59,15 @@ export function create({
             return promise
         }
         const result = hydration()
-        reaction(
+        const reactionRef = reaction(
             () => serialize(schema, store),
             (data: any) => storage.setItem(key, !jsonify ? data : JSON.stringify(data)),
             {
                 delay: debounce
             }
         )
+    
+        result.dispose = reactionRef;
         return result
     }
 }


### PR DESCRIPTION
Why ?
I have encountered use-case where I want to stop automatic storage updates at some point. This PR introduces possibility to call `.dispose()` on the hydration result in addition to `.rehydrate()`. Under the hood it just disposes of the mobx reaction.

 
