### PR TITLE
(docs): note redux-persist's Storage Engines compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ setTimeout(() => {
         Any Storage Engine that has a Promise-style API similar to [`localForage`](https://github.com/localForage/localForage).
         The default is `localStorage`, which has a built-in adaptor to make it support Promises.
         For React Native, one may configure `AsyncStorage` instead.
+        <br>
+        Any of [`redux-persist`'s Storage Engines](https://github.com/rt2zz/redux-persist#storage-engines) should also be compatible with `mobx-persist`.
       - **jsonify** *bool* Enables serialization as JSON
       - **debounce** *number* Debounce interval applied to storage calls (in miliseconds, default 0).
   - returns

--- a/README.md
+++ b/README.md
@@ -109,7 +109,10 @@ setTimeout(() => {
 #### `create(config)`
   - arguments
     - **config** *object* Describes the storage container you want your data to reside in.
-      - **storage** *[localForage](https://github.com/localForage/localForage)/AsyncStorage/localStorage* [localForage](https://github.com/localForage/localForage)-style storage API. localStorage for Web (default), AsyncStorage for React Native
+      - **storage** *[localForage](https://github.com/localForage/localForage) / AsyncStorage / localStorage*
+        Any Storage Engine that has a Promise-style API similar to [`localForage`](https://github.com/localForage/localForage).
+        The default is `localStorage`, which has a built-in adaptor to make it support Promises.
+        For React Native, one may configure `AsyncStorage` instead.
       - **jsonify** *bool* Enables serialization as JSON
       - **debounce** *number* Debounce interval applied to storage calls (in miliseconds, default 0).
   - returns


### PR DESCRIPTION
- redux-persist's Storage Engines all follow the same localForage-style
  async Promise API, so they should all be compatible with mobx-persist
  as well
  - docs should mention this as the interoperability adds many more
    usage options for developers
    - e.g. using node-storage or cookie-storage for Node or universal
      apps

Ripped out of https://github.com/agilgur5/mst-persist/pull/15 as discovered in https://github.com/agilgur5/mst-persist/issues/13

First commit back / collaboration since I created `mst-persist` from #37!  :) 