### PR TITLE
(docs): add section on Node and SSR Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ setTimeout(() => {
 }, 3000)
 ```
 
+### Node and Server-Side Rendering (SSR) Usage
+
+Node environments are supported so long as you configure a Storage Engine that supports Node, such as [`redux-persist-node-storage`](https://github.com/pellejacobs/redux-persist-node-storage), [`redux-persist-cookie-storage`](https://github.com/abersager/redux-persist-cookie-storage), etc.
+This allows you to hydrate your store server-side.
+
+For SSR though, you may not want to hydrate your store server-side, so in that case you can call `create` and `hydrate` conditionally:
+
+ ```javascript
+if (typeof window !== 'undefined') { // window is undefined in Node
+    const hydrate = create(...)
+    hydrate(...).then(...)
+}
+```
+
+With this conditional check, your store will only be hydrated client-side.
+
 ## API
 
 #### `persist(schema)(object)`


### PR DESCRIPTION
- note that one can hydrate server-side with Node and give some example
  storage engines one may use for that purpose
- note that server-side hydration can be skipped for certain use cases
  like SSR and give example for how to do so

Ripped out of https://github.com/agilgur5/mst-persist/pull/15 similar to #78.

This adds docs that were requested in #29 as well as some more around how one might intentionally use in Node for server-side hydration. The redux-persist storage links make a bit more sense once #78 is merged in.

